### PR TITLE
Loosen requirements for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.5",
-        "symfony/css-selector": "^6.0.3",
+        "symfony/css-selector": "^5.3|^6.0",
         "symfony/dom-crawler": "^6.0.3",
         "symfony/process": "^5.3|^6.0",
         "illuminate/collections": "^9.1",


### PR DESCRIPTION
This PR loosens the requirements for the `symfony/css-selector` package, allowing for use with PHP 8.0.