### PR TITLE
accounts for autocommitting fields

### DIFF
--- a/src/events/FactoryStoreEvent.php
+++ b/src/events/FactoryStoreEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace markhuot\craftpest\events;
+
+use craft\events\CancelableEvent;
+use markhuot\craftpest\factories\Factory;
+
+class FactoryStoreEvent extends CancelableEvent
+{
+    /** @var Factory */
+    public $sender;
+
+    /** @var mixed */
+    public $model;
+}

--- a/src/events/RollbackTransactionEvent.php
+++ b/src/events/RollbackTransactionEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace markhuot\craftpest\test;
+namespace markhuot\craftpest\events;
 
 use yii\base\Event;
 

--- a/src/exceptions/AutoCommittingFieldsException.php
+++ b/src/exceptions/AutoCommittingFieldsException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace markhuot\craftpest\exceptions;
+
+class AutoCommittingFieldsException extends \Exception
+{
+
+}

--- a/src/factories/Section.php
+++ b/src/factories/Section.php
@@ -11,6 +11,7 @@ use function markhuot\craftpest\helpers\base\array_wrap;
 
 /**
  * @method self type(string $type)
+ * @method Collection|\craft\models\Section create(array $definition=[])
  */
 class Section extends Factory {
 

--- a/src/test/RefreshesDatabase.php
+++ b/src/test/RefreshesDatabase.php
@@ -4,6 +4,7 @@ namespace markhuot\craftpest\test;
 
 use craft\helpers\ProjectConfig;
 use markhuot\craftpest\events\FactoryStoreEvent;
+use markhuot\craftpest\events\RollbackTransactionEvent;
 use markhuot\craftpest\exceptions\AutoCommittingFieldsException;
 use markhuot\craftpest\factories\Factory;
 use markhuot\craftpest\factories\Field;

--- a/tests/FactoryFieldTest.php
+++ b/tests/FactoryFieldTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use markhuot\craftpest\factories\{Section,Entry,Field};
+
+it ('creates entries and rolls back', function () {
+    $section = Section::factory()->create();
+    $entryCount = \craft\elements\Entry::find()->count();
+    Entry::factory()->section($section->handle)->count(5)->create();
+
+    test()->rollBackTransaction();
+    expect(\craft\elements\Entry::find()->count())->toBe($entryCount);
+});
+
+it ('creates fields and rolls back', function () {
+    Field::factory()->type(\craft\fields\PlainText::class)->create();
+
+    $section = Section::factory()->create();
+    $entryCount = \craft\elements\Entry::find()->count();
+    Entry::factory()->section($section->handle)->count(5)->create();
+
+    test()->rollBackTransaction();
+    expect(\craft\elements\Entry::find()->count())->toBe($entryCount);
+});
+
+it ('errors when trying to create fields after content elements', function () {
+    $this->expectException(\markhuot\craftpest\exceptions\AutoCommittingFieldsException::class);
+
+    Section::factory()->create();
+    Field::factory()->type(\craft\fields\PlainText::class)->create();
+});


### PR DESCRIPTION
This is a followup to @ostark's WIP here: https://github.com/markhuot/craft-pest/pull/16.

--

This change requires you to create fields before you create any "content" elements. This way content elements can be rolled back in the transaction and fields can be manually rolled back. This follows the React paradigm of "hooks come first" but for us it's "field factories come first."

I haven't tested this out with matrix fields because they're created so differently, but it works well/fine for creating sections and fields on the section!

Example (working) test would look like this,

```php
it ('creates fields and rolls back', function () {
    Field::factory()->type(\craft\fields\PlainText::class)->create();

    $section = Section::factory()->create();
    $entryCount = \craft\elements\Entry::find()->count();
    Entry::factory()->section($section->handle)->count(5)->create();

    test()->rollBackTransaction();
    expect(\craft\elements\Entry::find()->count())->toBe($entryCount);
});
```

Example (failing) test would look like this because by creating a Field after the section the DB would auto commit and and you'd be left with an orphaned Section that would never get cleaned up. Because the exception happens _before_ the auto commit from the field the section in this case is purged via the transaction so you're still left with a clean slate afterwards.

```php
it ('errors when trying to create fields after content elements', function () {
    $this->expectException(\markhuot\craftpest\exceptions\AutoCommittingFieldsException::class);

    Section::factory()->create();
    Field::factory()->type(\craft\fields\PlainText::class)->create();
});
```