### PR TITLE
Support passing pest options to craft pest/test command

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,7 @@
 name: PHP Composer
 
 on:
+  pull_request:
   push:
 
 permissions:

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -61,7 +61,14 @@ class TestController extends Controller {
      * Run the tests
      */
     protected function runTests() {
-        $process = new Process(['./vendor/bin/pest']);
+        $params = $this->request->getParams();
+        $pestOptions = [];
+
+        if ($params[1] === '--') {
+            $pestOptions = array_slice($params, 2);
+        }
+
+        $process = new Process(['./vendor/bin/pest', ...$pestOptions]);
         $process->setTty(true);
         $process->setTimeout(null);
         $process->start();

--- a/src/console/TestController.php
+++ b/src/console/TestController.php
@@ -63,9 +63,10 @@ class TestController extends Controller {
     protected function runTests() {
         $params = $this->request->getParams();
         $pestOptions = [];
+        $stdOutIndex = array_search('--', $params, true);
 
-        if ($params[1] === '--') {
-            $pestOptions = array_slice($params, 2);
+        if ($stdOutIndex !== false) {
+            $pestOptions = array_slice($params, ++$stdOutIndex);
         }
 
         $process = new Process(['./vendor/bin/pest', ...$pestOptions]);


### PR DESCRIPTION
This adds support for passing pest options through the craft command through stdout. Works similarly to how npm handles passing options to scripts.

For example:
```sh
./craft pest/test -- --coverage --order-by random
```