### PR TITLE
move acting as trait to pests 'uses' function.

### DIFF
--- a/src/test/TestCase.php
+++ b/src/test/TestCase.php
@@ -8,7 +8,7 @@ use markhuot\craftpest\web\TestableResponse;
 
 class TestCase extends \PHPUnit\Framework\TestCase {
 
-    use ActingAs, DatabaseAssertions;
+    use DatabaseAssertions;
 
     protected function setUp(): void
     {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,6 +13,7 @@
 
 uses(
     markhuot\craftpest\test\TestCase::class,
+    markhuot\craftpest\test\ActingAs::class,
     markhuot\craftpest\test\RefreshesDatabase::class,
 )->in('./');
 


### PR DESCRIPTION
I noticed today that the teardown method on the acting as trait wasn't being run between tests. It probably has something to do with extending the base `TestCase` class. If the trait is moved into `Pest.php` it still works and allows projects to extend the base test case a class of their own. 

```php
uses(
    TestCase::class, // <--- my custom testcase class that extends markhuot\craftpest\test\TestCase
    InitializesDatabase::class, // <-- another custom trait with setup/teardown
    markhuot\craftpest\test\RefreshesDatabase::class,
    ActingAs::class, // <--- available for when the base test case calls "callTraits"
)->in('./');
```