### PR TITLE
PoC: cookies are not working

### DIFF
--- a/src/config/app.web.php
+++ b/src/config/app.web.php
@@ -5,6 +5,13 @@ use markhuot\craftpest\web\Application;
 return [
     'class' => Application::class,
 
+    // Mark, is this the right place to enable the Module for internal tests?
+    'modules' => [
+        'pest-module-test' => \markhuot\craftpest\modules\test\Module::class,
+    ],
+    'bootstrap' => [
+        'pest-module-test',
+    ]
     // I dont want to force enable this here because there's a lot of logic in
     // the craft\web\Application::bootstrapDebug() that handles some edge cases. All
     // that custom logic is enabled with the `devMode` setting.

--- a/src/http/RequestBuilder.php
+++ b/src/http/RequestBuilder.php
@@ -38,6 +38,7 @@ class RequestBuilder
 
     public function addCookie(string $key, $value): self
     {
+        $this->request->cookies->readOnly = false;
         $this->request->cookies->add(new Cookie([
             'name' => $key,
             'value' => $value,

--- a/src/modules/test/controllers/TestController.php
+++ b/src/modules/test/controllers/TestController.php
@@ -3,6 +3,7 @@
 namespace markhuot\craftpest\modules\test\controllers;
 
 use craft\web\Controller;
+use yii\web\Cookie;
 
 class TestController extends Controller
 {
@@ -16,5 +17,24 @@ class TestController extends Controller
         $this->requirePostRequest();
 
         return $this->asJson(['foo' => 'bar']);
+    }
+
+    function actionCookieIncrement()
+    {
+        $this->requirePostRequest();
+
+        if ($cookie = \Craft::$app->getRequest()->getCookies()->get('c')) {
+            $cookie->value++;
+        } else {
+            $cookie = new Cookie([
+                'name' => 'c',
+                'value'=> 0,
+                'expire' => 100
+            ]);
+        }
+        \Craft::$app->getResponse()->getCookies()->readOnly = false;
+        \Craft::$app->getResponse()->getCookies()->add($cookie);
+
+        return $this->asJson(['counter' => $cookie->value]);
     }
 }

--- a/src/test/TestCase.php
+++ b/src/test/TestCase.php
@@ -10,8 +10,7 @@ class TestCase extends \PHPUnit\Framework\TestCase {
 
     use ActingAs,
         DatabaseAssertions,
-        RequestBuilders,
-        Benchmark;
+        RequestBuilders;
 
     protected function setUp(): void
     {

--- a/src/traits/RequestBuilders.php
+++ b/src/traits/RequestBuilders.php
@@ -91,6 +91,7 @@ trait RequestBuilders
     function action(string $action, array $body=[]): TestableResponse
     {
         return (new RequestBuilder('post', ''))
+            //->addCookie('c', 100)
             ->withCsrfToken()
             ->setBody([
                 'action' => $action,

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use markhuot\craftpest\factories\Entry;
+use markhuot\craftpest\factories\Section;
+use markhuot\craftpest\factories\User;
+    
+it ('increases a counter and keeps the value in a cookie', function () {
+    $user = User::factory()->admin(true)->create();
+    $this->actingAs($user);
+
+    // Initial request
+    $response0 = $this->action('pest-module-test/test/cookie-increment')->assertOk();
+    expect($response0->content)->toBeJson();
+    expect(json_decode($response0->content, true))->toBe(['counter' => 0]);
+
+    // Next request
+    $response1 = $this->action('pest-module-test/test/cookie-increment')->assertOk();
+    expect($response1->content)->toBeJson();
+    expect(json_decode($response1->content, true))->toBe(['counter' => 1]);
+
+
+});


### PR DESCRIPTION
We need to persist the cookie collection between requests - basically like a browser.
This is needed for sessions as well.

Idea: 

* enable cookie persistence by default across all tests
* OR enable cookie persistence by default within a single test at least
* provide an option to reset all cookies for the next request
