### PR TITLE
Fixed error when using Category factory

### DIFF
--- a/src/factories/Category.php
+++ b/src/factories/Category.php
@@ -26,5 +26,18 @@ class Category extends Element {
             'groupId' => $group->id,
         ]);
     }
+    
+    /**
+     * @inheritdoc
+     */
+    protected function setAttributes($attributes, $element)
+    {
+        // Set `groupId` early on the element so that it does break when trying to retrieve the field layout
+        if (isset($attributes['groupId'])) {
+            $element->groupId = $attributes['groupId'];
+            unset($attributes['groupId']);
+        }
 
+        return parent::setAttributes($attributes, $element);
+    }
 }

--- a/src/factories/Category.php
+++ b/src/factories/Category.php
@@ -32,6 +32,7 @@ class Category extends Element {
      */
     protected function setAttributes($attributes, $element)
     {
+        /** @var \craft\elements\Category $element */
         // Set `groupId` early on the element so that it does break when trying to retrieve the field layout
         if (isset($attributes['groupId'])) {
             $element->groupId = $attributes['groupId'];

--- a/src/factories/Category.php
+++ b/src/factories/Category.php
@@ -29,10 +29,10 @@ class Category extends Element {
     
     /**
      * @inheritdoc
+     * @param \craft\elements\Category $element
      */
     protected function setAttributes($attributes, $element)
     {
-        /** @var \craft\elements\Category $element */
         // Set `groupId` early on the element so that it does break when trying to retrieve the field layout
         if (isset($attributes['groupId'])) {
             $element->groupId = $attributes['groupId'];


### PR DESCRIPTION
Currently, when trying to use or extend a category factory there is an error on `create()`.

This is due to the code calling `fields()` on the element. Within this it is trying to get the field layout. Due to it being a category the field layout comes from the category group.

Therefore at [this point in the code](https://github.com/markhuot/craft-pest/blob/master/src/factories/Element.php#L106) with the `groupId` not already having been set an error occurs.

It, therefore, seems harmless to try and set this early. I wonder if there are potentially other attributes that might raise similar issues that really could do with being set earlier in the process.