### PR TITLE
Revise include paths for Craft 3.x to match Craft 4.x

### DIFF
--- a/src/bootstrap/bootstrap.php
+++ b/src/bootstrap/bootstrap.php
@@ -73,7 +73,7 @@ $originalConfig = file_get_contents(CRAFT_VENDOR_PATH . '/craftcms/cms/src/servi
 $originalConfig = preg_replace('/^<\?php/', '', $originalConfig);
 $originalConfig = preg_replace('/^namespace.*$/m', 'namespace markhuot\\craftpest\\overrides;', $originalConfig);
 eval($originalConfig);
-include './src/services/Config.php';
+include __DIR__ . '/../services/Config.php';
 $app = require CRAFT_VENDOR_PATH . '/craftcms/cms/bootstrap/web.php';
 
 $app->projectConfig->writeYamlAutomatically = false;

--- a/src/test/TestCase.php
+++ b/src/test/TestCase.php
@@ -55,7 +55,7 @@ class TestCase extends \PHPUnit\Framework\TestCase {
 
     protected function requireCraft()
     {
-        require './src/bootstrap/bootstrap.php';
+        require __DIR__ . '/../bootstrap/bootstrap.php';
     }
 
     public function factory(string $class)


### PR DESCRIPTION
This fixes an issue where Craft Pest may not be able to locate the bootstrap and config files.