### PR TITLE
Don't require dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Pest for Craft CMS
 
 ```shell
-composer require markhuot/craft-pest --dev
+composer require markhuot/craft-pest
 ./craft plugin/install pest
 ./craft pest/test
 ```
@@ -19,7 +19,7 @@ it('has a welcoming h1 element')
     ->get('/')
     ->expectSelector('h1')
     ->text->toBe('Welcome');
-        
+
 it('asserts nine list items')
     ->get('/')
     ->querySelector('li')
@@ -48,23 +48,23 @@ it('tests the kitchen sink', function () {
     // What's more, if a project.yaml is detected, Craft Pest will automatically check and
     // apply that config before each run to ensure you are always testing against a clean
     // schema.
-    $section = Section::factory()->create();     
-    
+    $section = Section::factory()->create();
+
     // Volume factories give you a local folder-based volume that ensures
     // your tests don't clutter your production S3 buckets, for example.
     $volume = Volume::factory()->create();
-    
+
     $entry = Entry::factory()
-    
+
         // Most fields on the entry factory can be defined just like you would'
-        // when querying `craft.entries` in a template. 
+        // when querying `craft.entries` in a template.
         ->section($section->handle)
-    
+
         // Even custom fields can be defined while creating an entry. This allows
         // you to mock/simulate a variety of content elements without needing to
         // pass around a complex and huge "seeding" database.
         ->isPromoted(true)
-        
+
         // Custom fields can be set to nested factories and will be automatically
         // created as they are needed.
         // Most factories can be utilized with as few as one additional field, like
@@ -79,16 +79,16 @@ it('tests the kitchen sink', function () {
     // For many people, just starting out with testing, their first (and only)
     // test is simply `$this->get('/')` to ensure the homepage loads.
     $this->get($entry->uri)
-    
+
         // All HTTP tests should probably check the status code of the response and
         // ensure Craft returned a 200 Ok response.
         ->assertOk()
-        
+
         // A response can be further inspected to check that the exact HTML matches
         // your expectations. Here the `querySelector` and `expectSelector` methods
         // allow you to parse over the response using a familiar CSS-based syntax.
         ->expectSelector('h1')
-        
+
         // Querying the HTML allows you to test the text, count, or even HTML of the
         // DOM to ensure it matches your expectations.
         ->text->toBe('Welcome');


### PR DESCRIPTION
First of all, thank you for the Plugin! I truly hope Pest becomes the standard for Craft CMS. 🙌 

When I followed the instructions in the readme I added the Plugin as a dev requirement. But afterwards, during a deployment, I got an error:

```
Installing plugin "pest" ... error: No plugin exists with the handle "pest".
```

During the deployment process, `composer install --no-dev` skips the development packages. But as suggested in the readme, the Plugin was locally installed and by that, added to the project.yaml.