### PR TITLE
Resets the content service because during a matrix save trying to get…

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        craftVersion: ["^3.7.33", "^4.2"]
+        craftVersion: ["~3.7.33", "^4.2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -74,10 +74,10 @@ jobs:
           vendor
         key: ${{ runner.os }}-craft-vendor-${{ matrix.craftVersion }}-${{ steps.cache-key.outputs.DYNAMIC_CACHE_KEY }}-${{ hashFiles('composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-craft-vendor-^3.7.33-
+          ${{ runner.os }}-craft-vendor-~3.7.33-
 
     - name: Install dependencies
-      run: composer update --with "craftcms/cms:^3.7.33" --prefer-dist --no-progress
+      run: composer update --with "craftcms/cms:~3.7.33" --prefer-dist --no-progress
 
     - name: Copy config files
       run: mkdir -p ./storage && cp -r ./stubs/config ./config
@@ -87,7 +87,7 @@ jobs:
 
     - name: Update to Craft ${{ matrix.craftVersion }}
       run: composer update --with "craftcms/cms:${{ matrix.craftVersion }}" -W && ./src/bin/craft migrate/all --no-backup=1 --interactive=0
-      if: matrix.craftVersion != '^3.7.33'
+      if: matrix.craftVersion != '~3.7.33'
 
     - name: Generate compiled classes
       run: ./src/bin/craft pest/ide/generate-mixins

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        craftVersion: ["^3.7", "^4.2"]
+        craftVersion: ["^3.7.33", "^4.2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
         CRAFT_VERSION: ${{ matrix.craftVersion }}
       run: |
         <?php
-        $env = "DYNAMIC_CACHE_KEY=" . (getenv("CRAFT_VERSION") != "3.7" ? time() : "");
+        $env = "DYNAMIC_CACHE_KEY=" . (getenv("CRAFT_VERSION") != "3.7.33" ? time() : "");
         file_put_contents(getenv('GITHUB_OUTPUT'), $env, FILE_APPEND);
       shell: php -f {0}
 
@@ -74,10 +74,10 @@ jobs:
           vendor
         key: ${{ runner.os }}-craft-vendor-${{ matrix.craftVersion }}-${{ steps.cache-key.outputs.DYNAMIC_CACHE_KEY }}-${{ hashFiles('composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-craft-vendor-^3.7-
+          ${{ runner.os }}-craft-vendor-^3.7.33-
 
     - name: Install dependencies
-      run: composer update --with "craftcms/cms:^3.7" --prefer-dist --no-progress
+      run: composer update --with "craftcms/cms:^3.7.33" --prefer-dist --no-progress
 
     - name: Copy config files
       run: mkdir -p ./storage && cp -r ./stubs/config ./config
@@ -87,7 +87,7 @@ jobs:
 
     - name: Update to Craft ${{ matrix.craftVersion }}
       run: composer update --with "craftcms/cms:${{ matrix.craftVersion }}" -W && ./src/bin/craft migrate/all --no-backup=1 --interactive=0
-      if: matrix.craftVersion != '^3.7'
+      if: matrix.craftVersion != '^3.7.33'
 
     - name: Generate compiled classes
       run: ./src/bin/craft pest/ide/generate-mixins

--- a/src/actions/RenderCompiledClasses.php
+++ b/src/actions/RenderCompiledClasses.php
@@ -2,12 +2,32 @@
 
 namespace markhuot\craftpest\actions;
 
+use craft\db\Table;
 use craft\helpers\FileHelper;
 use craft\helpers\StringHelper;
 
 class RenderCompiledClasses
 {
     function handle($forceRecreate=false)
+    {
+        $contentService = \Craft::$app->getContent();
+        $originalContentTable = $contentService->contentTable;
+        $originalFieldColumnPrefix = $contentService->fieldColumnPrefix;
+        $originalFieldContext = $contentService->fieldContext;
+        $contentService->contentTable = Table::CONTENT;
+        $contentService->fieldColumnPrefix = 'field_';
+        $contentService->fieldContext = 'global';
+
+        $this->render($forceRecreate);
+
+        $contentService->contentTable = $originalContentTable;
+        $contentService->fieldColumnPrefix = $originalFieldColumnPrefix;
+        $contentService->fieldContext = $originalFieldContext;
+
+        return true;
+    }
+
+    protected function render(bool $forceRecreate)
     {
         $storedFieldVersion = \Craft::$app->fields->getFieldVersion();
         $compiledClassesPath = __DIR__ . '/../storage/';
@@ -31,8 +51,6 @@ class RenderCompiledClasses
         ]);
 
         file_put_contents($compiledClassPath, $compiledClass);
-
-        return true;
     }
 
     protected function cleanupOldMixins(string $except=null)

--- a/src/factories/Entry.php
+++ b/src/factories/Entry.php
@@ -26,7 +26,7 @@ class Entry extends Element
     /** @var EntryType */
     protected $type;
 
-    /** @var string|\craft\models\Section */
+    /** @var string|\craft\models\Section|null */
     protected $sectionIdentifier;
 
     protected $priorityAttributes = ['sectionId', 'typeId'];


### PR DESCRIPTION
… global sets (to render type stubs) will fail when it uses the wrong field prefix