### PR TITLE
Fix support for fluent-based configs

### DIFF
--- a/src/craft/services/Config.php
+++ b/src/craft/services/Config.php
@@ -14,7 +14,7 @@ class Config extends \markhuot\craftpest\overrides\Config
         $original = parent::getConfigFromFile($filename);
 
         if (!is_array($original) || $filename !== 'app.web') {
-            return $original;
+            return collect($original)->toArray();
         }
 
         return array_merge($original, require __DIR__ . '/../../config/app.web.php');


### PR DESCRIPTION
This PR fixes support for fluent-based configs as per https://github.com/markhuot/craft-pest/issues/81#issuecomment-1486182316 and https://github.com/markhuot/craft-pest/issues/70#issuecomment-1366176693.

It reverts the change made in https://github.com/markhuot/craft-pest/pull/73/commits/602eeb62fee800f049b1be07845232071efc0607 which does not work because the method’s return type was set back to `array` to conform with inheritance rules.