### PR TITLE
Remove query string from `_fullUri`

### DIFF
--- a/src/http/requests/WebRequest.php
+++ b/src/http/requests/WebRequest.php
@@ -129,7 +129,7 @@ abstract class WebRequest extends \craft\web\Request
             '_isConsoleRequest' => false,
             '_fullPath' => $uri,
             '_path' => $uri,
-            '_fullUri' => $uri.'?'.$queryString,
+            '_fullUri' => $uri,
             '_ipAddress' => '::1',
             '_rawBody' => '',
             '_bodyParams' => [],


### PR DESCRIPTION
This PR removes the query string from the `_fullUri` property, which is in line with how Craft determines the full URI from the full path. 

See https://github.com/craftcms/cms/blob/d7641b8f17b55ed8857a45f2aacc818a45f58355/src/web/Request.php#L395