### PR TITLE
Fix deprecation notices

### DIFF
--- a/src/http/requests/WebRequest.php
+++ b/src/http/requests/WebRequest.php
@@ -122,7 +122,7 @@ abstract class WebRequest extends \craft\web\Request
 
         $isCpRequest = $this->uriContainsAdminSlug($uri);
         if ($isCpRequest) {
-            $uri = preg_replace('#^'.preg_quote(\Craft::$app->getConfig()->getGeneral()->cpTrigger).'/?#', '', $uri);
+            $uri = preg_replace('#^'.preg_quote((string) \Craft::$app->getConfig()->getGeneral()->cpTrigger).'/?#', '', $uri);
         }
 
         $this->setRaw([
@@ -150,7 +150,7 @@ abstract class WebRequest extends \craft\web\Request
     protected function uriContainsAdminSlug(string $uri): bool
     {
         $path = parse_url($uri, PHP_URL_PATH);
-        $slug = \Craft::$app->getConfig()->getGeneral()->cpTrigger ?? 'admin';
+        $slug = (string) \Craft::$app->getConfig()->getGeneral()->cpTrigger ?? 'admin';
 
         return str_starts_with(ltrim($path,'/'), $slug);
     }


### PR DESCRIPTION
Passing null to parameter to either `preg_quote` or `str_starts_with` has been deprecated. This fix will suppress the deprecation warnings in the terminal.